### PR TITLE
修复一些API

### DIFF
--- a/BiliClient/asyncBiliApi.py
+++ b/BiliClient/asyncBiliApi.py
@@ -989,7 +989,7 @@ class asyncBiliApi(object):
 
     async def xliveGetStatus(self) -> Awaitable[Dict[str, Any]]:
         '''B站直播获取金银瓜子状态'''
-        url = "https://api.live.bilibili.com/xlive/revenue/v1/wallet/myWallet?need_bp=1&need_metal=1&platform=pc"
+        url = "https://api.live.bilibili.com/xlive/revenue/v1/wallet/getStatus"
         async with self._session.get(url, verify_ssl=False) as r:
             ret = await r.json()
         return ret

--- a/BiliClient/asyncBiliApi.py
+++ b/BiliClient/asyncBiliApi.py
@@ -998,7 +998,8 @@ class asyncBiliApi(object):
         '''银瓜子兑换硬币'''
         url = "https://api.live.bilibili.com/pay/v1/Exchange/silver2coin"
         post_data = {
-            "csrf_token": self._bili_jct
+            "csrf_token": self._bili_jct,
+            "csrf": self._bili_jct
             }
         async with self._session.post(url, data=post_data, verify_ssl=False) as r:
             return await r.json()

--- a/BiliClient/asyncBiliApi.py
+++ b/BiliClient/asyncBiliApi.py
@@ -906,9 +906,9 @@ class asyncBiliApi(object):
             "csrf_token": self._bili_jct,
             "csrf": self._bili_jct,
             }
-        enc_server = 'https://1578907340179965.cn-shanghai.fc.aliyuncs.com/2016-08-15/proxy/bili_server/heartbeat/'
+        enc_server = 'http://heartbeat-1.mudew.com:3000/enc'
         async with self._session.post(enc_server, json={"t":post_data,"r":secret_rule}, verify_ssl=False) as r:
-            post_data["s"] = await r.text()
+            post_data["s"] = (await r.json())["s"]
 
         url = 'https://live-trace.bilibili.com/xlive/data-interface/v1/x25Kn/X'
         async with self._session.post(url, data=post_data, verify_ssl=False) as r:

--- a/BiliExp.py
+++ b/BiliExp.py
@@ -148,31 +148,44 @@ def main(args):
 
     init_message(configData) #初始化消息推送
 
+    if "looping" not in configData:
+        configData["looping"] = None
+    if "random" not in configData:
+        configData["random"] = None
+    if "timing" not in configData:
+        configData["timing"] = []
+
+    for i in range(len(configData["timing"])):
+        configData["timing"][i]=datetime.time.fromisoformat(configData["timing"][i])
+    
+    looping = args.looping or configData["looping"]
+    timing = args.timing or configData["timing"]
+    random_max = args.random or configData["random"]
     #启动任务
     loop = asyncio.get_event_loop()
-    if args.looping:
+    if looping:
         while True:
             task=loop.create_task(start(configData))
             loop.run_until_complete(task)
-            time.sleep(args.looping)
-            if args.random:
-                random_time = random.randint(1, args.random)
+            time.sleep(looping)
+            if random_max:
+                random_time = random.randint(1, random_max)
                 logging.info(f'随机延时{random_time}s')
                 time.sleep(random_time)
-    elif args.timing:
+    elif timing:
         while True:
             now = datetime.datetime.now().time().replace(microsecond=0)
-            if now in args.timing: # 此处为设置的每天定时的时间
-                if args.random:
-                    random_time = random.randint(1, args.random)
+            if now in timing: # 此处为设置的每天定时的时间
+                if random_max:
+                    random_time = random.randint(1, random_max)
                     logging.info(f'随机延时{random_time}s')
                     time.sleep(random_time)
                 task=loop.create_task(start(configData))
                 loop.run_until_complete(task)
                 time.sleep(2)
     else:
-        if args.random:
-            random_time = random.randint(1, args.random)
+        if random_max:
+            random_time = random.randint(1, random_max)
             logging.info(f'随机延时{random_time}s')
             time.sleep(random_time)
         task=loop.create_task(start(configData))

--- a/Docker/Dockerfile-runner
+++ b/Docker/Dockerfile-runner
@@ -1,11 +1,13 @@
 FROM python:3.8.3-alpine
 MAINTAINER 星辰
 
-RUN apk add --no-cache build-base libffi-dev \
+RUN apk add --no-cache build-base libffi-dev tzdata\
  && pip --no-cache-dir install aiohttp requests json5 \
+ && cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
+ && echo "Asia/Shanghai" >  /etc/timezone \
  && rm -rf ~/.cache/pip \
  && rm -rf /tmp/* \
- && apk del libffi-dev build-base
+ && apk del libffi-dev build-base tzdata
 
 COPY entrypoint.sh ./entrypoint.sh
 

--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -53,6 +53,7 @@ fi
 
 function download(){
   wget -O /tmp/BiliExp.zip https://archive.fastgit.org/MaxSecurity/BiliExper/archive/master.zip
+  [ "$?" != 0 ] && return
   unzip /tmp/BiliExp.zip -d /tmp
   rm /tmp/BiliExp.zip
   [ -d /tmp/BiliExp ] && rm -rf /tmp/BiliExp

--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -11,10 +11,10 @@ while getopts "t:dc:" opt; do
     t)
       tag=$OPTARG
       ;;
-	d)
+    d)
       daemon="yes"
       ;;
-	c)
+    c)
       cron=$OPTARG
       ;;
     \?)
@@ -51,16 +51,19 @@ fi
 #   fi
 # fi
 
-wget -O /tmp/BiliExp.zip https://archive.fastgit.org/MaxSecurity/BiliExper/archive/master.zip
-unzip /tmp/BiliExp.zip -d /tmp
-rm /tmp/BiliExp.zip
-mv /tmp/BiliExp* /tmp/BiliExp
+function download(){
+  wget -O /tmp/BiliExp.zip https://archive.fastgit.org/MaxSecurity/BiliExper/archive/master.zip
+  unzip /tmp/BiliExp.zip -d /tmp
+  rm /tmp/BiliExp.zip
+  [ -d /tmp/BiliExp ] && rm -rf /tmp/BiliExp
+  mv /tmp/BiliExp* /tmp/BiliExp
 
-cd /tmp/BiliExp
-
-if [ -f "./Docker/init.sh" ]; then
-  /bin/sh "./Docker/init.sh";
-fi
+  if [ -f "/tmp/BiliExp/Docker/init.sh" ]; then
+    /bin/sh "/tmp/BiliExp/Docker/init.sh";
+  fi
+}
+# 下载代码
+download
 
 #执行代码
 if [ $daemon = "yes" ];then
@@ -68,7 +71,10 @@ if [ $daemon = "yes" ];then
   /usr/sbin/crond start
   while :;do
     sleep 24h
+    # 每24小时下载一次代码（用作更新）
+    pkill -9 python3
+    download
   done
 else
-  /usr/local/bin/python3 BiliExp.py -c /BiliExp/config.json -l /BiliExp/BiliExp.log
+  cd /tmp/BiliExp && /usr/local/bin/python3 BiliExp.py -c /BiliExp/config.json -l /BiliExp/BiliExp.log
 fi

--- a/config/config.json
+++ b/config/config.json
@@ -252,6 +252,9 @@
     },
     "log_file": "BiliExp.log",   // 输出日志文件，不输出请留空，也可填写完整路径
     "log_console": true,         // 是否把日志输出到控制台
+    "looping": 0,         // 循环间隔，单位为秒，设置为0则不启用，也可以使用命令行启用（命令行优先），可运行命令 python3 BiliExp.py -h 查看，与timing互斥
+    "timing": [],          // 定时执行，格式为HH:mm:ss，空列表则不启用，也可以使用命令行启用（命令行优先），可运行命令 python3 BiliExp.py -h 查看，与looping互斥
+    "random": 0,          // 随机延时范围，单位为秒，设置为0不启用，也可以使用命令行启用（命令行优先），可运行命令 python3 BiliExp.py -h 查看
     "users": [{                 //账户数组，每个账户包含一个cookieDatas和tasks参数，使用actions的用户可以使用secrets(biliconfig)指定cookie而不用本参数
         "cookieDatas": {        // cookie获取方式见项目说明
             "SESSDATA": "xxxxx",

--- a/tasks/group_sign_task.py
+++ b/tasks/group_sign_task.py
@@ -22,11 +22,11 @@ async def group_sign_task(biliapi: asyncbili) -> None:
             logging.warning(f'{biliapi.name}: 给{group["group_name"]}应援异常，原因为{str(e)}')
             er += 1
         else:
-            if ret["code"] == 0 and ret["data"]["status"] == 0:
+            if sign["code"] == 0 and sign["data"]["status"] == 0:
                 logging.info(f'{biliapi.name}: 给{group["group_name"]}应援成功')
                 su += 1
             else:
-                logging.info(f'{biliapi.name}: 给{group["group_name"]}应援失败，原因为:{ret["message"]}')
+                logging.info(f'{biliapi.name}: 给{group["group_name"]}应援失败，原因为:{sign["message"]}')
                 er += 1
     if er > 0:
         webhook.addMsg('msg_simple', f'{biliapi.name}:应援团签到成功{su}个,失败{er}个\n')

--- a/tasks/group_sign_task.py
+++ b/tasks/group_sign_task.py
@@ -15,14 +15,14 @@ async def group_sign_task(biliapi: asyncbili) -> None:
         return
 
     su, er = 0, 0
-    for group in ret["data"]:
+    for group in ret["data"]["list"]:
         try:
             sign = await biliapi.groupSign(group["group_id"], group["owner_uid"])
         except Exception as e:
             logging.warning(f'{biliapi.name}: 给{group["group_name"]}应援异常，原因为{str(e)}')
             er += 1
         else:
-            if ret["code"] == 0:
+            if ret["code"] == 0 and ret["data"]["status"] == 0:
                 logging.info(f'{biliapi.name}: 给{group["group_name"]}应援成功')
                 su += 1
             else:

--- a/tasks/silver2coin_task.py
+++ b/tasks/silver2coin_task.py
@@ -6,7 +6,7 @@ async def silver2coin_task(biliapi: asyncbili) -> None:
    try:
        ret = await biliapi.xliveGetStatus()
        if ret["code"] != 0:
-           logging.warning(f'{biliapi.name}: 获取瓜子信息失败，信息为({ret["msg"]})，跳过兑换硬币')
+           logging.warning(f'{biliapi.name}: 获取瓜子信息失败，信息为({ret["message"]})，跳过兑换硬币')
            webhook.addMsg('msg_simple', f'{biliapi.name}:瓜子转硬币失败\n')
            return
    except Exception as e: 
@@ -21,7 +21,7 @@ async def silver2coin_task(biliapi: asyncbili) -> None:
    try:
        ret = await biliapi.silver2coin()
        if ret["code"] != 0:
-           logging.warning(f'{biliapi.name}: 银瓜子兑换硬币失败，信息为({ret["msg"]})')
+           logging.warning(f'{biliapi.name}: 银瓜子兑换硬币失败，信息为({ret["message"]})')
            webhook.addMsg('msg_simple', f'{biliapi.name}:瓜子转硬币失败\n')
        else:
            logging.info(f'{biliapi.name}: 成功将银瓜子兑换为1个硬币')

--- a/tasks/xlive_bag_send_task.py
+++ b/tasks/xlive_bag_send_task.py
@@ -27,6 +27,8 @@ async def xlive_bag_send_task(biliapi: asyncbili,
                  ret = await biliapi.xliveBagSend(room_id, uid, x["bag_id"], x["gift_id"], x["gift_num"])
                  if ret["code"] == 0:
                      logging.info(f'{biliapi.name}: {ret["data"]["send_tips"]} {ret["data"]["gift_name"]} 数量{ret["data"]["gift_num"]}')
+                 else:
+                     logging.info(f'{biliapi.name}:在直播间{room_id}送出礼物失败，{ret["message"]}')
          if not ishave:
              logging.info(f'{biliapi.name}: 没有{expire}s内过期的直播礼物，跳过赠送')
     except Exception as e:


### PR DESCRIPTION

- 修改加密服务器：原来的加密服务器不能用了，换了https://github.com/lkeme/BiliHelper-personal 该作者的，和原来的接口不一样，所以也改了一下获取加密key的方法。

- 修复应援团签到：bilibili接口增加了一层list。

- 修复docker的entrypoint.sh 文件中的下载：好像我改了好几次，希望这次我没有再忘记啥。。。😂
- 修复金银瓜子状态获取API：bilibili的API换了
- docker启动时清理BiliExp旧日志：启动时清理旧日志，防止日志滚动过多，不过这样改好像也不咋地
- 修复应援团签到
- docker use Aisa/Shanghai timezone：让docker镜像用 Aisa/Shanghai时区
- 打印送出即将过期的礼物时的错误消息
- 修复银瓜子兑换硬币
- 添加运行时的命令参数：**这个修改会破坏原来的直接Python启动挂机的命令**，原因是原来的会让docker与函数计算运行程序时会出现程序不结束导致重复运行，而且原来的while 循环内执行main程序会导致线程重复添加执行task。这个修改增加了`looping`和`timing`两个启动参数，`looping`参数为循环运行间隔，`timing`参数为定时运行时间，主要提供给Python直接启动挂机时使用。
- 修复银瓜子兑换硬币
- 添加运行时的命令参数： 添加参数`random`用于随机延时的范围设置
- 使用argparse取代了getopt:  `argparse`比`getopt`更友好些