### PR TITLE
[兼容腾讯云函数]将args转换为dict类型

### DIFF
--- a/BiliExp.py
+++ b/BiliExp.py
@@ -255,4 +255,6 @@ if __name__=="__main__":
     )
 
     args = parser.parse_args()
+    if not isinstance(args,dict):
+        args = vars(args)
     main(args)


### PR DESCRIPTION
python3.6.1中args为dict，高版本中为Namespace（一个具有可读字符串表示形式的 object），为了兼容性将其转换为dict
Close https://github.com/MaxSecurity/BiliExper/issues/26