### PR TITLE
修复loggile取值

### DIFF
--- a/BiliExp.py
+++ b/BiliExp.py
@@ -152,7 +152,7 @@ def main(args,*kwargs):
         sys.exit(6)
 
     if args.get("logfile",None):
-        configData["log_file"] = args.logfile
+        configData["log_file"] = args.get("logfile")
 
     init_message(configData) #初始化消息推送
 


### PR DESCRIPTION
args转为Dict后，无法通过`args.logfile`获取logfile的值，改为使用`args.get("logfile")`取值